### PR TITLE
D3log UUID

### DIFF
--- a/d3log/Cargo.toml
+++ b/d3log/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = "1.0.60"
 phf = {version="0.8", features = ["macros"]}
 mm = {version = "0.1.0", path = "mm_ddlog"}
 serde = { version = "1.0", features = ["derive"] }
+rand = "0.8.3"

--- a/d3log/d3.dl
+++ b/d3log/d3.dl
@@ -1,13 +1,17 @@
 // this file intented to specify the 'syscall interface' for the
-// d3log supervisor
+// d3log supervisor. it seems like it needs to have related
+// but not identical definitions?
 
 // this is really everyone we ever hear from. importantly - is this
 // a global relation, or a local one (myself, other)
-input relation Workers(x: D3logLocationId)
+input relation Workers(location: D3logLocationId)
 
 // should include the source address, port, and timestamp
 // we dont actually know the nid w/o negotiation
-input relation Connection(x: D3logLocationId)
+input relation Connection(me: D3logLocationId, them:D3logLocationId)
 
 // we should have address types here
-input relation TcpAddress(x: D3logLocationId, destination: string)
+input relation TcpAddress(location: D3logLocationId, destination: string)
+
+// this isn't part of the 'syscall interface', but something we use internally
+index TcpAddress_by_location(from: D3logLocationId) on TcpAddress(from, _)

--- a/d3log/issues
+++ b/d3log/issues
@@ -14,3 +14,6 @@ differential_datalog/src/program/update.rs (DeleteKey, etc)?
 we are assuming that each scc is evaluated in a given node, but
 there isn't anything that stopping us from using a @ within a function
 cycle.
+
+code - 
+  what error type should we be using universally internally? 

--- a/d3log/src/batch.rs
+++ b/d3log/src/batch.rs
@@ -110,7 +110,7 @@ impl Display for Batch {
             }
             f.write_str(&format!(" {})", m))?;
         }
-        f.write_str(&format!(">"))?;
+        f.write_str(&">")?;
         Ok(())
     }
 }
@@ -155,6 +155,13 @@ impl IntoIterator for Batch {
             relations: Box::new(self.deltas.into_iter()),
             items: None,
         }
+    }
+}
+
+// clippy says
+impl Default for Batch {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/d3log/src/batch.rs
+++ b/d3log/src/batch.rs
@@ -1,3 +1,7 @@
+// a module to support a set of updates and provide some convencience functions
+// over them, in particular general serde support. This currently sits on top
+// of DeltaMap, but that might change
+
 use differential_datalog::{ddval::DDValue, program::RelId, program::Update, DeltaMap};
 
 // not really, we aren't going to be compiling against the user program

--- a/d3log/src/batch.rs
+++ b/d3log/src/batch.rs
@@ -155,15 +155,15 @@ impl IntoIterator for Batch {
 }
 
 impl Batch {
-    // there should be a new that allocates it own and a from deltamap for
-    // the wrap case
-
     pub fn from(b: DeltaMap<differential_datalog::ddval::DDValue>) -> Batch {
-        Batch { b, timestamp: 0 }        
+        Batch { b, timestamp: 0 }
     }
-    
+
     pub fn new() -> Batch {
-        Batch { b: DeltaMap::<differential_datalog::ddval::DDValue>::new(), timestamp: 0 }
+        Batch {
+            b: DeltaMap::<differential_datalog::ddval::DDValue>::new(),
+            timestamp: 0,
+        }
     }
 
     pub fn insert(&mut self, r: RelId, v: differential_datalog::ddval::DDValue, weight: u32) {

--- a/d3log/src/batch.rs
+++ b/d3log/src/batch.rs
@@ -59,7 +59,7 @@ impl<'de> Visitor<'de> for BatchVisitor {
     where
         E: SeqAccess<'de>,
     {
-        let mut b = Batch::new(DeltaMap::new());
+        let mut b = Batch::new();
 
         let t: Option<u64> = e.next_element()?;
         match t {
@@ -158,8 +158,12 @@ impl Batch {
     // there should be a new that allocates it own and a from deltamap for
     // the wrap case
 
-    pub fn new(b: DeltaMap<differential_datalog::ddval::DDValue>) -> Batch {
-        Batch { b, timestamp: 0 }
+    pub fn from(b: DeltaMap<differential_datalog::ddval::DDValue>) -> Batch {
+        Batch { b, timestamp: 0 }        
+    }
+    
+    pub fn new() -> Batch {
+        Batch { b: DeltaMap::<differential_datalog::ddval::DDValue>::new(), timestamp: 0 }
     }
 
     pub fn insert(&mut self, r: RelId, v: differential_datalog::ddval::DDValue, weight: u32) {
@@ -182,7 +186,7 @@ pub fn singleton(
         }
     };
 
-    let mut d = Batch::new(DeltaMap::<differential_datalog::ddval::DDValue>::new());
+    let mut d = Batch::new();
     d.insert(mrel, v.clone(), 1);
     Ok(d)
 }

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -51,19 +51,8 @@ async fn read_output(t: ArcTransactionManager, f: Box<Fd>) -> Result<(), std::io
         let res = pin.read(&mut buffer).await?;
         for i in jf.append(&buffer[0..res])? {
             let v: Batch = serde_json::from_str(&i)?;
-            println!("eval{}", v);
-            match t.clone().eval(v).await {
-                Ok(b) => {
-                    // println!("eval completez {}", b);
-                    // shouldn't exit on eval error
-                    t.forward(b).await?; // not really dude
-                }
-
-                Err(x) => {
-                    println!("erraru rivalu!");
-                    return Err(Error::new(ErrorKind::Other, x));
-                }
-            };
+            // shouldn't exit on eval error
+            t.forward(t.clone().eval(v)?)?
         }
     }
 }

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -62,16 +62,16 @@ async fn read_output(t: ArcTransactionManager, f: Box<Fd>) -> Result<(), std::io
 }
 
 pub fn start_node(f: Vec<Fd>) {
-    let t = ArcTransactionManager::new();
-    let n = ArcTcpNetwork::new();
-    let rt = Runtime::new().unwrap();
-    let _eg = rt.enter();
+    let rt = Runtime::new().unwrap();    
+    let _eg = rt.enter();    
+    let tm = ArcTransactionManager::new();
+    let tn = ArcTcpNetwork::new(tm);
 
     rt.block_on(async move {
         for i in f {
-            let tclone = t.clone();
+            let tmclone = tm.clone();
             spawn(async move {
-                match read_output(tclone, Box::new(i)).await {
+                match read_output(tmclone, Box::new(i)).await {
                     Ok(_) => (),
                     Err(x) => {
                         println!("err {}", x);
@@ -79,7 +79,9 @@ pub fn start_node(f: Vec<Fd>) {
                 }
             });
         }
-        match n.bind(t).await {
+        
+        // return address through here?
+        match tn.bind().await {
             Ok(_) => (),
             Err(x) => {
                 panic!("bind failure {}", x);

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -76,9 +76,8 @@ pub fn start_node(f: Vec<Fd>) {
     });
 
     let am = Arc::new(m);
-
     let tm = ArcTransactionManager::new(uuid, am.clone());
-    let tn = Box::new(ArcTcpNetwork::new(uuid, am.clone(), tm));
+    let tn = Box::new(ArcTcpNetwork::new(uuid, am.clone(), tm.clone()));
     // bind network to tm
 
     rt.block_on(async move {

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -65,7 +65,7 @@ pub fn start_node(f: Vec<Fd>) {
     let rt = Runtime::new().unwrap();    
     let _eg = rt.enter();    
     let tm = ArcTransactionManager::new();
-    let tn = ArcTcpNetwork::new(tm);
+    let tn = ArcTcpNetwork::new(tm.clone());
 
     rt.block_on(async move {
         for i in f {

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -1,10 +1,6 @@
 use crate::{
-    json_framer::JsonFramer,
-    tcp_network::ArcTcpNetwork,
-    transact::ArcTransactionManager,
-    Batch,
-    Node,
-    Transport
+    json_framer::JsonFramer, tcp_network::ArcTcpNetwork, transact::ArcTransactionManager, Batch,
+    Node, Transport,
 };
 
 use tokio::{io::AsyncReadExt, io::AsyncWriteExt, runtime::Runtime, spawn};
@@ -24,8 +20,8 @@ const CHILD_OUTPUT_FD: Fd = 4;
 // xxx child read input
 
 struct FileDescriptor {
-    input : Fd,
-    output : Fd,
+    input: Fd,
+    output: Fd,
 }
 
 impl Transport for FileDescriptor {
@@ -36,11 +32,11 @@ impl Transport for FileDescriptor {
             Err(_x) => return Err(Error::new(ErrorKind::Other, "oh no!")),
         };
         let mut pin = AsyncFd::try_from(self.output)?;
-        tokio::spawn(async move {pin.write_all(js.as_bytes()).await});
+        tokio::spawn(async move { pin.write_all(js.as_bytes()).await });
         Ok(())
     }
 }
-    
+
 pub async fn output_json(k: &Batch) -> Result<(), std::io::Error> {
     //    println!("{}", serde_json::to_string(&k)?);
     let js = match serde_json::to_string(&k) {
@@ -85,8 +81,8 @@ async fn read_output(t: ArcTransactionManager, f: Box<Fd>) -> Result<(), std::io
 }
 
 pub fn start_node(f: Vec<Fd>) {
-    let rt = Runtime::new().unwrap();    
-    let _eg = rt.enter();    
+    let rt = Runtime::new().unwrap();
+    let _eg = rt.enter();
     let tm = ArcTransactionManager::new();
     let tn = ArcTcpNetwork::new(tm.clone());
 
@@ -102,7 +98,7 @@ pub fn start_node(f: Vec<Fd>) {
                 }
             });
         }
-        
+
         // return address through here?
         match tn.bind().await {
             Ok(_) => (),

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -133,10 +133,6 @@ pub fn make_child() -> Result<(Fd, Fd), nix::Error> {
 // i would kind of prefer to kick off init from inside ddlog, but
 // odaat
 
-//Shouldn't this function return a Result that tells you whether or
-// not it succeeded in starting all children? If so that'd make some
-// of the inner logic a lot cleaner
-
 pub fn start_children(n: usize, _init: Batch) -> Result<(), std::io::Error> {
     let mut children_in = Vec::<Fd>::new();
     let mut children_out = Vec::<Fd>::new();

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -26,7 +26,7 @@ struct FileDescriptor {
 
 impl Transport for FileDescriptor {
     fn send(&self, _nid: Node, b: Batch) -> Result<(), std::io::Error> {
-        // use chases unwrap
+        // there doesn't seem to be a nice unwrap for error rewriting - i guess a macro
         let js = match serde_json::to_string(&b) {
             Ok(x) => x,
             Err(_x) => return Err(Error::new(ErrorKind::Other, "oh no!")),
@@ -35,18 +35,6 @@ impl Transport for FileDescriptor {
         tokio::spawn(async move { pin.write_all(js.as_bytes()).await });
         Ok(())
     }
-}
-
-pub async fn output_json(k: &Batch) -> Result<(), std::io::Error> {
-    //    println!("{}", serde_json::to_string(&k)?);
-    let js = match serde_json::to_string(&k) {
-        Ok(x) => x,
-        Err(_x) => return Err(Error::new(ErrorKind::Other, "oh no!")),
-    };
-    let mut pin = AsyncFd::try_from(CHILD_OUTPUT_FD)?;
-    // write_all??
-    pin.write(js.as_bytes()).await?;
-    Ok(())
 }
 
 // this is the self-framed json input from stdout of one of my children
@@ -85,17 +73,17 @@ pub fn start_node(f: Vec<Fd>) {
     let _eg = rt.enter();
     let tm = ArcTransactionManager::new();
     let tn = ArcTcpNetwork::new(tm.clone());
+    // set tm.management!
 
     rt.block_on(async move {
         for i in f {
             let tmclone = tm.clone();
             spawn(async move {
-                match read_output(tmclone, Box::new(i)).await {
-                    Ok(_) => (),
-                    Err(x) => {
-                        println!("err {}", x);
-                    } // process exit
-                }
+                read_output(tmclone, Box::new(i))
+                    .await
+                    .unwrap_or_else(|error| {
+                        panic!("err {}", error);
+                    })
             });
         }
 
@@ -138,7 +126,7 @@ pub fn make_child() -> Result<(Fd, Fd), nix::Error> {
 // not it succeeded in starting all children? If so that'd make some
 // of the inner logic a lot cleaner
 
-pub fn start_children(n: usize, _init: Batch) {
+pub fn start_children(n: usize, _init: Batch) -> Result<(), std::io::Error> {
     let mut children_in = Vec::<Fd>::new();
     let mut children_out = Vec::<Fd>::new();
 
@@ -149,11 +137,10 @@ pub fn start_children(n: usize, _init: Batch) {
                 children_in.push(from);
                 children_out.push(to);
             }
-            Err(x) => {
-                panic!("fork failed {}", x);
-            }
+            Err(x) => return Err(Error::new(ErrorKind::Other, format!("oh no! {}", x))),
         }
     }
     // wire up nid 0s address..no one is listening to my stdin!
     start_node(children_in);
+    Ok(())
 }

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -84,8 +84,7 @@ pub fn start_node(f: Vec<Fd>) {
     let am = Arc::new(m);
     let tm = ArcTransactionManager::new(uuid, am.clone());
     let tn = Box::new(ArcTcpNetwork::new(uuid, am.clone(), tm.clone()));
-    // bind network to tm
-
+    tm.clone().set_network(tn.clone());
     println!("start");
     rt.block_on(async move {
         for i in f {

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -134,6 +134,10 @@ pub fn make_child() -> Result<(Fd, Fd), nix::Error> {
 // i would kind of prefer to kick off init from inside ddlog, but
 // odaat
 
+//Shouldn't this function return a Result that tells you whether or
+// not it succeeded in starting all children? If so that'd make some
+// of the inner logic a lot cleaner
+
 pub fn start_children(n: usize, _init: Batch) {
     let mut children_in = Vec::<Fd>::new();
     let mut children_out = Vec::<Fd>::new();

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -1,3 +1,10 @@
+// functions for managing forked children.
+// - start_node(), which is the general d3log runtime start, and probably doesn't belong here
+// - implementation of Port over pipes
+//
+// this needs to get broken apart or shifted a little since the children in the future
+// will be other ddlog executables
+
 use crate::{
     json_framer::JsonFramer, tcp_network::ArcTcpNetwork, transact::ArcTransactionManager, Batch,
     Node, Port, Transport,

--- a/d3log/src/child.rs
+++ b/d3log/src/child.rs
@@ -41,7 +41,6 @@ impl Transport for FileDescriptor {
             Ok(x) => x,
             Err(x) => panic!("encoding error {}", x),
         };
-        println!("management {}", js);
         let mut pin = AsyncFd::try_from(self.output).expect("asynch");
         tokio::spawn(async move { pin.write_all(js.as_bytes()).await });
     }
@@ -59,7 +58,6 @@ async fn read_output(t: ArcTransactionManager, f: Box<Fd>) -> Result<(), std::io
     let mut buffer = [0; 64];
     loop {
         let res = pin.read(&mut buffer).await?;
-        println!("read {}", std::str::from_utf8(&buffer[0..res]).expect(""));
         for i in jf.append(&buffer[0..res])? {
             let v: Batch = serde_json::from_str(&i)?;
             // shouldn't exit on eval error

--- a/d3log/src/json_framer.rs
+++ b/d3log/src/json_framer.rs
@@ -73,21 +73,18 @@ impl JsonFramer {
                     self.reassembly.push(*i);
                 }
 
-                match ENDS.get(c) {
-                    Some(k) => {
-                        if *k != self.w.pop().expect("mismatched grouping") {
-                            return Err(Error::new(ErrorKind::Other, "mismatched grouping"));
-                        }
-                        if self.w.is_empty() {
-                            n.push(
-                                std::str::from_utf8(&self.reassembly[..])
-                                    .map_err(|_| Error::new(ErrorKind::Other, "utf8 error"))?
-                                    .to_owned(),
-                            );
-                            self.reassembly.truncate(0);
-                        }
+                if let Some(k) = ENDS.get(c) {
+                    if *k != self.w.pop().expect("mismatched grouping") {
+                        return Err(Error::new(ErrorKind::Other, "mismatched grouping"));
                     }
-                    None => (),
+                    if self.w.is_empty() {
+                        n.push(
+                            std::str::from_utf8(&self.reassembly[..])
+                                .map_err(|_| Error::new(ErrorKind::Other, "utf8 error"))?
+                                .to_owned(),
+                        );
+                        self.reassembly.truncate(0);
+                    }
                 }
             }
         }

--- a/d3log/src/json_framer.rs
+++ b/d3log/src/json_framer.rs
@@ -1,3 +1,15 @@
+// this module pre-frames json objects out of an arbitrarily chunked byte string.
+// it is a really terrible idea to temporarily work around some limtations
+// with serde. specifically that it can read chunked blocks and a sequence
+// of self-framed json objects, but not both
+//
+// haven't been able to understand it yet but
+// https://github.com/TimelyDataflow/timely-dataflow/blob/master/timely/src/dataflow/operators/to_stream.rs#L73
+// may lead to a better answer.
+//
+// if it were going to stay Lexement should really just be the leading group
+// character
+
 use phf::{phf_map, phf_set};
 use std::io::{Error, ErrorKind};
 

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -8,7 +8,7 @@ use crate::{batch::Batch, child::start_children, typedefs::matrix::Matrix};
 
 use differential_datalog::ddval::DDValConvert;
 use differential_datalog::D3logLocationId;
-use differential_datalog::DeltaMap;
+
 use mm_ddlog::*;
 use rustop::opts;
 use std::str;
@@ -21,7 +21,7 @@ trait Transport {
     
 use std::convert::TryFrom;
 fn matrix(mat: Vec<Vec<u64>>) -> Result<Batch, String> {
-    let mut b = Batch::new(DeltaMap::new());
+    let mut b = Batch::new();
     let relid = Relations::try_from("matrix::Matrix")
         .map_err(|_| format!("Unknown relation {}", "Matrix"))?;
 

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -1,3 +1,5 @@
+// temporary main that runs the trivial matrix multiply example. this
+// will instead turn into supervisor main
 mod batch;
 mod child;
 mod json_framer;

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -20,6 +20,7 @@ trait Transport {
 }
 
 type Port = Box<(dyn Transport + Send + Sync)>;
+
 use std::convert::TryFrom;
 fn matrix(mat: Vec<Vec<u64>>) -> Result<Batch, String> {
     let mut b = Batch::new();

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -51,7 +51,6 @@ fn main() {
     }
     .parse_or_exit();
 
-    // blocking
     start_children(
         args.nodes,
         match matrix(vec![vec![1, 2, 3], vec![7, 12, 19], vec![5, 3, 1]]) {
@@ -62,4 +61,5 @@ fn main() {
             }
         },
     )
+    .expect("start children failed");
 }

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -16,9 +16,9 @@ use std::str;
 type Node = D3logLocationId;
 
 trait Transport {
-    fn send(&self, nid: Node, b: Batch) -> Result<(), std::io::Error> ;
+    fn send(&self, nid: Node, b: Batch) -> Result<(), std::io::Error>;
 }
-    
+
 use std::convert::TryFrom;
 fn matrix(mat: Vec<Vec<u64>>) -> Result<Batch, String> {
     let mut b = Batch::new();

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -15,7 +15,7 @@ use std::str;
 
 type Node = D3logLocationId;
 
-trait Transport {
+pub trait Transport {
     fn send(&self, nid: Node, b: Batch) -> Result<(), std::io::Error>;
 }
 

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -19,6 +19,7 @@ trait Transport {
     fn send(&self, nid: Node, b: Batch) -> Result<(), std::io::Error>;
 }
 
+type Port = Box<(dyn Transport + Send + Sync)>;
 use std::convert::TryFrom;
 fn matrix(mat: Vec<Vec<u64>>) -> Result<Batch, String> {
     let mut b = Batch::new();

--- a/d3log/src/main.rs
+++ b/d3log/src/main.rs
@@ -16,7 +16,10 @@ use std::str;
 type Node = D3logLocationId;
 
 pub trait Transport {
-    fn send(&self, nid: Node, b: Batch) -> Result<(), std::io::Error>;
+    // since most of these errors are async, we're adopting a general
+    // policy for the moment of making all errors async and reported out
+    // of band
+    fn send(&self, nid: Node, b: Batch);
 }
 
 type Port = Box<(dyn Transport + Send + Sync)>;

--- a/d3log/src/tcp_network.rs
+++ b/d3log/src/tcp_network.rs
@@ -42,12 +42,12 @@ pub struct ArcTcpNetwork {
 }
 
 impl ArcTcpNetwork {
-    pub fn new(me: Node, management: Port, tm: ArcTransactionManager) -> ArcTcpNetwork {
+    pub fn new(me: Node, management: Arc<Port>, tm: ArcTransactionManager) -> ArcTcpNetwork {
         ArcTcpNetwork {
             n: Arc::new(SyncMutex::new(TcpNetwork {
                 peers: Arc::new(Mutex::new(HashMap::new())),
                 sends: Arc::new(SyncMutex::new(Vec::new())),
-                management: Arc::new(management),
+                management,
                 me,
                 tm,
             })),

--- a/d3log/src/tcp_network.rs
+++ b/d3log/src/tcp_network.rs
@@ -155,7 +155,7 @@ impl Transport for ArcTcpNetwork {
             let target_string = tuple.destination.to_string();
             let target: SocketAddr = target_string
                 .parse()
-                .expect(&format!("bad tcp address {}", target_string));
+                .unwrap_or_else(|_| panic!("bad tcp address {}", target_string));
 
             // this is racy because we keep having to drop this lock across
             // await. if we lose, there will be a once used but after idle

--- a/d3log/src/tcp_network.rs
+++ b/d3log/src/tcp_network.rs
@@ -128,7 +128,7 @@ impl ArcTcpNetwork {
 // should this be one instance per transport type, or one per peer - seems
 // like the latter really
 impl Transport for ArcTcpNetwork {
-    fn send(&self, nid: Node, b: Batch) -> Result<(), std::io::Error> {
+    fn send(&self, nid: Node, b: Batch) {
         let peers = {
             let peers = &mut (*self.n.lock().expect("lock")).peers;
             peers.clone()
@@ -182,6 +182,5 @@ impl Transport for ArcTcpNetwork {
             }
         });
         (*self.n.lock().expect("lock").sends.lock().expect("lock")).push(completion);
-        Ok(())
     }
 }

--- a/d3log/src/tcp_network.rs
+++ b/d3log/src/tcp_network.rs
@@ -26,6 +26,7 @@ use std::sync::Mutex as SyncMutex;
 
 #[derive(Clone)]
 pub struct TcpNetwork {
+    // The double-synchronization here is fairly suspect to me
     peers: Arc<Mutex<HashMap<Node, Arc<Mutex<TcpStream>>>>>,
     sends: Arc<SyncMutex<Vec<JoinHandle<Result<(), std::io::Error>>>>>, // ;JoinHandle<()>>>>,
     tm: ArcTransactionManager,
@@ -96,7 +97,7 @@ impl ArcTcpNetwork {
                                     Ok(x) => x,
                                     Err(x) => panic!(x),
                                 };
-                                println!("{}", v);
+                                println!("receive {}", v);
                             }
                         }
                         Err(x) => panic!("read error {}", x),

--- a/d3log/src/tcp_network.rs
+++ b/d3log/src/tcp_network.rs
@@ -13,61 +13,23 @@ use tokio::{
     task::JoinHandle,
 };
 
-use mm_ddlog::typedefs::d3::{Connection, Workers};
+use mm_ddlog::typedefs::d3::{Connection, TcpAddress};
 
 use crate::batch::singleton;
 use crate::child::output_json;
 use crate::{json_framer::JsonFramer, transact::ArcTransactionManager, Batch, Node, Transport};
 
-use differential_datalog::ddval::DDValConvert;
+use differential_datalog::ddval::{DDValConvert};
 use std::collections::HashMap; //, HashSet};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{SocketAddr};
 use std::sync::Arc;
 use std::sync::Mutex as SyncMutex;
-
-
-// to be destroyed
-pub fn address_to_nid(peer: SocketAddr) -> Node {
-    let i = match peer.ip() {
-        IpAddr::V4(x) => x.octets(),
-        IpAddr::V6(_) => return 0,
-    };
-    let p = peer.port().to_be_bytes();
-
-    // prefer big endian for generic reasons, but we are travelling through
-    // a constricted u64 pipe
-    u128::from_le_bytes([
-        i[0], i[1], i[2], i[3], p[0], p[1], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    ])
-}
-
-pub fn nid_to_socketaddr(n: Node) -> SocketAddr {
-    let b = n.to_le_bytes();
-    SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(b[0], b[1], b[2], b[3])),
-        u16::from_be_bytes([b[4], b[5]]),
-    )
-}
 
 #[derive(Clone)]
 pub struct TcpNetwork {
     peers: Arc<Mutex<HashMap<Node, Arc<Mutex<TcpStream>>>>>,
     sends: Arc<SyncMutex<Vec<JoinHandle<Result<(), std::io::Error>>>>>, // ;JoinHandle<()>>>>,
-}
-
-// we wanted to make a network class, that would have a send function, and
-// that would allow us to encapsulate quite a bit about our environment.
-//
-// there is an async_trait macro that promises to do this, but unsurprisingly
-// MutexGuard does not implement Send. So its unclear how to let such
-// a trait function mutate. punting.
-impl TcpNetwork {
-    pub fn new() -> TcpNetwork {
-        TcpNetwork {
-            peers: Arc::new(Mutex::new(HashMap::new())),
-            sends: Arc::new(SyncMutex::new(Vec::new())),
-        }
-    }
+    tm: ArcTransactionManager
 }
 
 #[derive(Clone)]
@@ -76,32 +38,45 @@ pub struct ArcTcpNetwork {
 }
 
 impl ArcTcpNetwork {
-    pub fn new() -> ArcTcpNetwork {
+    pub fn new(tm: ArcTransactionManager) -> ArcTcpNetwork {
         ArcTcpNetwork {
-            n: Arc::new(SyncMutex::new(TcpNetwork::new())),
-        }
+            n: Arc::new(SyncMutex::new(
+                TcpNetwork {
+                    peers: Arc::new(Mutex::new(HashMap::new())),
+                    sends: Arc::new(SyncMutex::new(Vec::new())),
+                    tm,
+                }))}
     }
 
     // xxx - caller should get the address and send the address fact, not us
-    pub async fn bind(&self, _t: ArcTransactionManager) -> Result<(), std::io::Error> {
+    pub async fn bind(&self) -> Result<(), std::io::Error> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
-
         let a = listener.local_addr().unwrap();
-        let nid = address_to_nid(a);
-        let w = Workers { x: nid }.into_ddvalue();
-        output_json(&(singleton("d3::Workers", &w)?)).await?;
+
+        {
+            let tm = &(*self.n.lock().expect("lock")).tm;
+            output_json(&(singleton("d3::TcpAddress", 
+                                    &TcpAddress {
+                                        location: tm.myself(),
+                                        destination: a.to_string(),
+                                    }.into_ddvalue()))?).await?;
+        }
+        
         loop {
-            let (socket, a) = listener.accept().await?;
+            // exchange ids
+            let (socket, _a) = listener.accept().await?;
 
-            let c = Connection {
-                x: address_to_nid(a),
+            {
+                let tm = self.n.lock().expect("lock").tm.clone();
+                let m = tm.myself();
+                tm.metadata( "d3::Connection", Connection {
+                    me: m,
+                    them: m,
+                }.into_ddvalue());
             }
-            .into_ddvalue();
-            output_json(&(singleton("d3::Connection", &c)?)).await?;
-
+            
             // well, this is a huge .. something. if i just use the socket
-            // in the async move block, it actually gets dropped. what
-            // happened to ultimate safety?
+            // in the async move block, it actually gets dropped
             let sclone = Arc::new(Mutex::new(socket));
             tokio::spawn(async move {
                 let mut jf = JsonFramer::new();
@@ -144,6 +119,11 @@ impl Transport for ArcTcpNetwork {
             let encoded = serde_json::to_string(&b).expect("tcp network send json encoding error");
             println!("send {} {} {}", nid, b, encoded.chars().count());
 
+            let ddv = &Record::u128{nid}.to_ddvalue;
+            let target_dd = self.n.lock().expect("lock").tm.lookup("TcpAddress_by_location", ddv)?;
+            let target_string = target_dd.to_string();
+            let target = target_string.parse();
+            
             // this is racy because we keep having to drop this lock across
             // await. if we lose, there will be a once used but after idle
             // connection
@@ -151,11 +131,11 @@ impl Transport for ArcTcpNetwork {
                 .lock()
                 .await
                 .entry(nid)
-                .or_insert(match TcpStream::connect(nid_to_socketaddr(nid)).await {
+                .or_insert(match TcpStream::connect(target).await {
                     Ok(x) => {
                         Arc::new(Mutex::new(x))
                     }
-                    Err(_x) => panic!("connection failure {}", nid_to_socketaddr(nid)),
+                    Err(_x) => panic!("connection failure {}", target),
                 })
                 .lock()
                 .await

--- a/d3log/src/transact.rs
+++ b/d3log/src/transact.rs
@@ -1,4 +1,6 @@
-// general module for managing transactions into and out of ddlog
+// general module for managing transactions into and out of ddlog. currently
+// this means just feeding batches and splitting them up for distribution - but
+// single-value-serialization/progress would go here
 
 use crate::{batch::Batch, Node, Port};
 use differential_datalog::{

--- a/d3log/src/transact.rs
+++ b/d3log/src/transact.rs
@@ -1,9 +1,9 @@
+// general module for managing transactions into and out of ddlog
+
 use crate::tcp_network::ArcTcpNetwork;
 use crate::{batch::{Batch, singleton}, Node, Transport, child::output_json};
-//use async_std::sync::Mutex;
 use differential_datalog::{program::Update, D3log, DDlog, DDlogDynamic, DDlogInventory,
                            ddval::{DDValConvert, DDValue}};
-
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as SyncMutex;

--- a/d3log/src/transact.rs
+++ b/d3log/src/transact.rs
@@ -22,7 +22,7 @@ pub struct TransactionManager {
     // which causes this small mess
     network: Option<Port>,
 
-    management: Port,
+    management: Arc<Port>,
     evaluator: HDDlog,
     me: Node,
 }
@@ -47,9 +47,12 @@ pub struct ArcTransactionManager {
 }
 
 impl ArcTransactionManager {
-    pub fn new(uuid: Node, management: Port) -> ArcTransactionManager {
+    pub fn new(uuid: Node, management: Arc<Port>) -> ArcTransactionManager {
         let tm = ArcTransactionManager {
-            t: Arc::new(SyncMutex::new(TransactionManager::new(uuid, management))),
+            t: Arc::new(SyncMutex::new(TransactionManager::new(
+                uuid,
+                management.clone(),
+            ))),
         };
 
         management.send(
@@ -141,7 +144,7 @@ impl ArcTransactionManager {
 impl TransactionManager {
     fn start() {}
 
-    pub fn new(me: Node, management: Port) -> TransactionManager {
+    pub fn new(me: Node, management: Arc<Port>) -> TransactionManager {
         let (hddlog, _init_output) = HDDlog::run(1, false)
             .unwrap_or_else(|err| panic!("Failed to run differential datalog: {}", err));
 

--- a/d3log/src/transact.rs
+++ b/d3log/src/transact.rs
@@ -92,7 +92,7 @@ impl ArcTransactionManager {
             let tma = &*self.t.lock().expect("lock");
             // fix tm network mutual reference
             if let Some(n) = &tma.network {
-                n.send(nid, *b)?
+                n.send(nid, *b)
             }
         }
         Ok(())

--- a/d3log/src/transact.rs
+++ b/d3log/src/transact.rs
@@ -91,7 +91,6 @@ impl ArcTransactionManager {
 
         for (nid, b) in output.drain() {
             let tma = &*self.t.lock().expect("lock");
-            // fix tm network mutual reference
             if let Some(n) = &tma.network {
                 n.send(nid, *b)
             }
@@ -103,7 +102,6 @@ impl ArcTransactionManager {
         let tm = self.t.lock().expect("lock");
         let h = &(*tm).evaluator;
 
-        println!("eval {}", input);
         let mut upd = Vec::new();
         for (relid, v, _) in input {
             upd.push(Update::Insert { relid, v });
@@ -132,6 +130,11 @@ impl ArcTransactionManager {
             .query_index(tma.evaluator.get_index_id(&index_name)?, key)?;
         // insert method on batch please
         Ok(results.into_iter().next())
+    }
+
+    // to be deleted
+    pub fn set_network(self, p: Port) {
+        self.t.lock().unwrap().network = Some(p);
     }
 }
 

--- a/d3log/src/transact.rs
+++ b/d3log/src/transact.rs
@@ -1,11 +1,7 @@
 // general module for managing transactions into and out of ddlog
 
 use crate::tcp_network::ArcTcpNetwork;
-use crate::{
-    batch::{singleton, Batch},
-    child::output_json,
-    Node, Transport,
-};
+use crate::{batch::Batch, child::output_json, Node, Transport};
 use differential_datalog::{
     ddval::{DDValConvert, DDValue},
     program::Update,
@@ -58,7 +54,7 @@ impl ArcTransactionManager {
         };
 
         // fix network and tm mutual reference
-        tm.clone().t.lock().expect("lock").n = Some(Box::new(ArcTcpNetwork::new(tm.clone())));
+        tm.t.lock().expect("lock").n = Some(Box::new(ArcTcpNetwork::new(tm.clone())));
 
         // race between this and tcp network
 
@@ -146,7 +142,7 @@ impl ArcTransactionManager {
     pub fn metadata(self, relation: &'static str, v: DDValue) {
         // collect completions
         tokio::spawn(async move {
-            output_json(&(singleton(relation, &v).expect("bad metadata relation"))).await
+            output_json(&(Batch::singleton(relation, &v).expect("bad metadata relation"))).await
         });
     }
 }


### PR DESCRIPTION
a bit of a hodgepodge - 
   stop encoding network addresses directly in the location and provide a relation to map opaque locations to network endpoints

   continue to add comments and assuage clippy

   since send is no longer exposed as async, make it a proper trait so we can genericize the plumbing a little better
   